### PR TITLE
move Money::Money outside of spree namespace

### DIFF
--- a/app/models/spree/currency_rate.rb
+++ b/app/models/spree/currency_rate.rb
@@ -10,14 +10,14 @@ module Spree
       amount_in_krw = amount.to_money("KRW")
       usd_rate = 1 / self.rate
       ::Money::Money.add_rate(self.target_currency,self.base_currency,usd_rate)
-      amount_in_usd = Money::Money.new(amount_in_krw,'KRW').exchange_to('USD')
+      amount_in_usd = ::Money::Money.new(amount_in_krw,'KRW').exchange_to('USD')
       amount_in_usd
     end
 
     def convert_to_won(amount)
       amount_in_usd = amount.to_money("USD")
-      Money::Money.add_rate(self.base_currency,self.target_currency,self.rate)
-      amount_in_won = Money::Money.us_dollar(amount_in_usd).exchange_to('KRW')
+      ::Money::Money.add_rate(self.base_currency,self.target_currency,self.rate)
+      amount_in_won = ::Money::Money.us_dollar(amount_in_usd).exchange_to('KRW')
       amount_in_won
     end
 


### PR DESCRIPTION
Was receiving these warning messages:

``` ruby
/Users/benmorgan/.rvm/gems/ruby-2.1.4/bundler/gems/spree_currency_converter-f6489671bdf7/app/models/spree/currency_rate.rb:19: warning: toplevel constant Money referenced by Spree::Money::Money
/Users/benmorgan/.rvm/gems/ruby-2.1.4/bundler/gems/spree_currency_converter-f6489671bdf7/app/models/spree/currency_rate.rb:20: warning: toplevel constant Money referenced by Spree::Money::Money
```

This should fix that.
